### PR TITLE
Fix a broken link to the obs-websocket documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Click [here](https://github.com/IRLToolkit/simpleobsws/tree/simpleobsws-4.x) to 
 
 ## Docs:
 - Library docs: [the sort-of docs](/usage.md)
-- obs-websocket docs: https://github.com/Palakis/obs-websocket/blob/4.x-current/docs/generated/protocol.md
+- obs-websocket docs: https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md
 
 ## Samples:
 Samples are located in the samples folder [here.](/samples)


### PR DESCRIPTION
Link to the current documentation.